### PR TITLE
Add doze to display and Notification Ticker/heads-up disable

### DIFF
--- a/res/values/aosp_arrays.xml
+++ b/res/values/aosp_arrays.xml
@@ -228,4 +228,17 @@
         <item>BR</item>
         <item>IN</item>
     </string-array>
+
+     <!-- Ticker mode -->
+    <string-array name="ticker_mode_entries">
+        <item>@string/ticker_disabled</item>
+        <item>@string/ticker_enabled</item>
+        <item>@string/ticker_media_enabled</item>
+    </string-array>
+
+    <string-array name="ticker_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 </resources> 

--- a/res/values/aosp_strings.xml
+++ b/res/values/aosp_strings.xml
@@ -211,4 +211,9 @@
     <string name="ticker_title">Ticker</string>
     <string name="ticker_summary">Enable the old status bar notification ticker. Do not use in conjunction with Heads Up.</string>
 
+    <!-- Heads up -->
+    <string name="heads_up_notifications">Heads up</string>
+    <string name="summary_heads_up_enabled">Pop-up notifications are enabled</string>
+    <string name="summary_heads_up_disabled">Pop-up notifications are disabled</string>
+
 </resources>

--- a/res/values/aosp_strings.xml
+++ b/res/values/aosp_strings.xml
@@ -207,4 +207,8 @@
     <string name="op_doze_title">Doze</string>
     <string name="op_doze_summary">Control ambient display for your device</string>
 
+    <!-- Status bar notification ticker -->
+    <string name="ticker_title">Ticker</string>
+    <string name="ticker_summary">Enable the old status bar notification ticker. Do not use in conjunction with Heads Up.</string>
+
 </resources>

--- a/res/values/aosp_strings.xml
+++ b/res/values/aosp_strings.xml
@@ -210,6 +210,9 @@
     <!-- Status bar notification ticker -->
     <string name="ticker_title">Ticker</string>
     <string name="ticker_summary">Enable the old status bar notification ticker. Do not use in conjunction with Heads Up.</string>
+    <string name="ticker_disabled">No ticker</string>
+    <string name="ticker_enabled">Notification ticker</string>
+    <string name="ticker_media_enabled">Notifications and music ticker</string>
 
     <!-- Heads up -->
     <string name="heads_up_notifications">Heads up</string>

--- a/res/values/aosp_strings.xml
+++ b/res/values/aosp_strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2017 The JDCTeam
+     Copyright (C) 2017 AOSiP
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -202,4 +202,9 @@
     <string name="wifi_setting_countrycode_summary">Specify the region code for Wi\u2011Fi</string>
     <!-- Wi-Fi settings screen, error message when the frequency band could not be set [CHAR LIMIT=50]. -->
     <string name="wifi_setting_countrycode_error">There was a problem setting the region code.</string>
+
+    <!-- Device Specific Doze -->
+    <string name="op_doze_title">Doze</string>
+    <string name="op_doze_summary">Control ambient display for your device</string>
+
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -130,19 +130,26 @@
                 android:title="@string/rebindings_settings_title"
                 android:summary="@string/rebindings_settings_summary"/>
 
-    <com.android.settings.preference.SystemSettingSwitchPreference
+         <com.android.settings.preference.SystemSettingSwitchPreference
                 android:key="status_bar_show_ticker"
                 android:title="@string/ticker_title"
                 android:summary="@string/ticker_summary"
                 android:defaultValue="false" />
 
-        <PreferenceScreen
+         <!-- Heads up -->
+         <com.android.settings.preference.GlobalSettingSwitchPreference
+                android:key="heads_up_notifications_enabled"
+                android:title="@string/heads_up_notifications"
+                android:summaryOn="@string/summary_heads_up_enabled"
+                android:summaryOff="@string/summary_heads_up_disabled" />
+
+         <PreferenceScreen
                 android:key="wifi_display"
                 android:title="@string/wifi_display_settings_title"
                 settings:keywords="@string/keywords_display_cast_screen"
                 android:fragment="com.android.settings.wfd.WifiDisplaySettings" />
 
-        <DropDownPreference
+         <DropDownPreference
                 android:key="vr_display_pref"
                 android:summary="%s"
                 android:title="@string/display_vr_pref_title" />

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -84,6 +84,13 @@
                 android:title="@string/doze_title"
                 android:summary="@string/doze_summary" />
 
+        <PreferenceScreen
+                android:key="doze_device"
+                android:title="@string/op_doze_title"
+                android:summary="@string/op_doze_summary" >
+                <intent android:action="org.cyanogenmod.settings.device.DOZE_SETTINGS" />
+        </PreferenceScreen>
+
         <SwitchPreference
                 android:key="tap_to_wake"
                 android:title="@string/tap_to_wake"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -130,11 +130,12 @@
                 android:title="@string/rebindings_settings_title"
                 android:summary="@string/rebindings_settings_summary"/>
 
-         <com.android.settings.preference.SystemSettingSwitchPreference
+         <ListPreference
+                android:entries="@array/ticker_mode_entries"
+                android:entryValues="@array/ticker_mode_values"
                 android:key="status_bar_show_ticker"
-                android:title="@string/ticker_title"
-                android:summary="@string/ticker_summary"
-                android:defaultValue="false" />
+                android:summary="%s"
+                android:title="@string/ticker_title" />
 
          <!-- Heads up -->
          <com.android.settings.preference.GlobalSettingSwitchPreference

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -130,6 +130,12 @@
                 android:title="@string/rebindings_settings_title"
                 android:summary="@string/rebindings_settings_summary"/>
 
+    <com.android.settings.preference.SystemSettingSwitchPreference
+                android:key="status_bar_show_ticker"
+                android:title="@string/ticker_title"
+                android:summary="@string/ticker_summary"
+                android:defaultValue="false" />
+
         <PreferenceScreen
                 android:key="wifi_display"
                 android:title="@string/wifi_display_settings_title"

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -144,7 +144,8 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
         }
 
         if (isDozeAvailable(activity)) {
-            removePreference(KEY_DOZE);
+            mDozePreference = (SwitchPreference) findPreference(KEY_DOZE);
+            mDozePreference.setOnPreferenceChangeListener(this);
         } else {
             removePreference(KEY_DOZE);
         }

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -40,6 +40,7 @@ import android.support.v14.preference.SwitchPreference;
 import android.support.v7.preference.DropDownPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceScreen;
 import android.support.v7.preference.Preference.OnPreferenceChangeListener;
 import android.text.TextUtils;
 import android.util.Log;
@@ -82,6 +83,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final String KEY_SCREEN_SAVER = "screensaver";
     private static final String KEY_LIFT_TO_WAKE = "lift_to_wake";
     private static final String KEY_DOZE = "doze";
+    private static final String KEY_DOZE_DEVICE = "doze_device";
     private static final String KEY_TAP_TO_WAKE = "tap_to_wake";
     private static final String KEY_AUTO_BRIGHTNESS = "auto_brightness";
     private static final String KEY_AUTO_ROTATE = "auto_rotate";
@@ -96,6 +98,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private TimeoutListPreference mScreenTimeoutPreference;
     private ListPreference mNightModePreference;
     private Preference mScreenSaverPreference;
+    private PreferenceScreen mDozeDevicePreference;
     private SwitchPreference mLiftToWakePreference;
     private SwitchPreference mDozePreference;
     private SwitchPreference mTapToWakePreference;
@@ -150,6 +153,13 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             mDozePreference.setOnPreferenceChangeListener(this);
         } else {
             removePreference(KEY_DOZE);
+        }
+
+        if (isDeviceDozeInstalled) {
+            mDozeDevicePreference = (PreferenceScreen) findPreference(KEY_DOZE_DEVICE);
+            mDozeDevicePreference.setOnPreferenceChangeListener(this);
+        } else {
+            removePreference(KEY_DOZE_DEVICE);
         }
 
         if (isTapToWakeAvailable(getResources())) {

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -98,6 +98,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
 
     private TimeoutListPreference mScreenTimeoutPreference;
     private ListPreference mNightModePreference;
+    private ListPreference mShowTicker;
     private Preference mScreenSaverPreference;
     private PreferenceScreen mDozeDevicePreference;
     private SwitchPreference mLiftToWakePreference;
@@ -105,7 +106,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private SwitchPreference mTapToWakePreference;
     private SwitchPreference mAutoBrightnessPreference;
     private SwitchPreference mCameraGesturePreference;
-    private SwitchPreference mShowTicker;
 
     @Override
     protected int getMetricsCategory() {
@@ -261,11 +261,13 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             mNightModePreference.setOnPreferenceChangeListener(this);
         }
 
-        mShowTicker = (SwitchPreference) findPreference(STATUS_BAR_SHOW_TICKER);
+        mShowTicker = (ListPreference) findPreference(STATUS_BAR_SHOW_TICKER);
         mShowTicker.setOnPreferenceChangeListener(this);
-        int ShowTicker = Settings.System.getInt(getContentResolver(),
-                STATUS_BAR_SHOW_TICKER, 0);
-        mShowTicker.setChecked(ShowTicker != 0);
+        int tickerMode = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.STATUS_BAR_SHOW_TICKER,
+                0, UserHandle.USER_CURRENT);
+        mShowTicker.setValue(String.valueOf(tickerMode));
+        mShowTicker.setSummary(mShowTicker.getEntry());
     }
 
     private static boolean allowAllRotations(Context context) {
@@ -456,10 +458,13 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
                 Log.e(TAG, "could not persist night mode setting", e);
             }
         }
-        if (preference == mShowTicker) {
-            boolean value = (Boolean) objValue;
-            Settings.Global.putInt(getContentResolver(), STATUS_BAR_SHOW_TICKER,
-                    value ? 1 : 0);
+        if (preference.equals(mShowTicker)) {
+            int tickerMode = Integer.parseInt(((String) objValue).toString());
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.STATUS_BAR_SHOW_TICKER, tickerMode,
+                    UserHandle.USER_CURRENT);
+            int index = mShowTicker.findIndexOfValue((String) objValue);
+            mShowTicker.setSummary(mShowTicker.getEntries()[index]);
         }
         return true;
     }

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -92,6 +92,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final String KEY_CAMERA_GESTURE = "camera_gesture";
     private static final String KEY_WALLPAPER = "wallpaper";
     private static final String KEY_VR_DISPLAY_PREF = "vr_display_pref";
+    private static final String STATUS_BAR_SHOW_TICKER = "status_bar_show_ticker";
 
     private Preference mFontSizePref;
 
@@ -104,6 +105,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private SwitchPreference mTapToWakePreference;
     private SwitchPreference mAutoBrightnessPreference;
     private SwitchPreference mCameraGesturePreference;
+    private SwitchPreference mShowTicker;
 
     @Override
     protected int getMetricsCategory() {
@@ -258,6 +260,12 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             mNightModePreference.setValue(String.valueOf(currentNightMode));
             mNightModePreference.setOnPreferenceChangeListener(this);
         }
+
+        mShowTicker = (SwitchPreference) findPreference(STATUS_BAR_SHOW_TICKER);
+        mShowTicker.setOnPreferenceChangeListener(this);
+        int ShowTicker = Settings.System.getInt(getContentResolver(),
+                STATUS_BAR_SHOW_TICKER, 0);
+        mShowTicker.setChecked(ShowTicker != 0);
     }
 
     private static boolean allowAllRotations(Context context) {
@@ -447,6 +455,11 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             } catch (NumberFormatException e) {
                 Log.e(TAG, "could not persist night mode setting", e);
             }
+        }
+        if (preference == mShowTicker) {
+            boolean value = (Boolean) objValue;
+            Settings.Global.putInt(getContentResolver(), STATUS_BAR_SHOW_TICKER,
+                    value ? 1 : 0);
         }
         return true;
     }

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -47,6 +47,7 @@ import android.util.Log;
 import com.android.internal.app.NightDisplayController;
 import com.android.internal.logging.MetricsLogger;
 import com.android.internal.logging.MetricsProto.MetricsEvent;
+import com.android.internal.util.jdcteam.jdcUtils;
 import com.android.internal.view.RotationPolicy;
 import com.android.settings.accessibility.ToggleFontSizePreferenceFragment;
 import com.android.settings.dashboard.SummaryLoader;
@@ -111,6 +112,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
         super.onCreate(savedInstanceState);
         final Activity activity = getActivity();
         final ContentResolver resolver = activity.getContentResolver();
+        final boolean isDeviceDozeInstalled = jdcUtils.isPackageInstalled(activity, "com.cyanogenmod.settings.doze");
 
         addPreferencesFromResource(R.xml.display_settings);
 
@@ -143,7 +145,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             removePreference(KEY_LIFT_TO_WAKE);
         }
 
-        if (isDozeAvailable(activity)) {
+        if (isDozeAvailable(activity) && !isDeviceDozeInstalled) {
             mDozePreference = (SwitchPreference) findPreference(KEY_DOZE);
             mDozePreference.setOnPreferenceChangeListener(this);
         } else {


### PR DESCRIPTION
With these we are going to need the doze commits tested on all devices, and @MZO9400 and other one plus guys i would need you to make sure your doze commits are up to date with these, https://github.com/AOSP-JF-MM/platform_device_oneplus_oneplus3/commits/aosp-7.1.2/doze or it will still be in main settings and not in display.